### PR TITLE
create a device by MAC, name and deviceType

### DIFF
--- a/BBPebbleLib/Bluetooth/BluetoothDevice.cpp
+++ b/BBPebbleLib/Bluetooth/BluetoothDevice.cpp
@@ -5,12 +5,33 @@
  *      Author: James
  */
 
+#include <QtConnectivity/QBluetoothAddress>
+
 #include "BluetoothDevice.h"
 
-BluetoothDevice::BluetoothDevice(const QBluetoothDeviceInfo& device, QObject *parent) : QObject(parent)
-{
-    this->m_device = device;
 
+BluetoothDevice::BluetoothDevice(const QBluetoothDeviceInfo& device, QObject *parent)
+    : QObject(parent)
+    , m_device(device)
+{
+    init();
+}
+
+BluetoothDevice::BluetoothDevice(const QString& mac, const QString& name, quint32 deviceClass, QObject *parent)
+    :QObject(parent)
+{
+    m_device = QBluetoothDeviceInfo(QtMobility::QBluetoothAddress(mac), name, deviceClass);
+
+    init();
+}
+
+BluetoothDevice::~BluetoothDevice()
+{
+
+}
+
+void BluetoothDevice::init()
+{
     connect(&m_socket, SIGNAL(readyRead()), this, SLOT(readyRead()));
     connect(&m_socket, SIGNAL(connected()), this, SIGNAL(connected()));
     connect(&m_socket, SIGNAL(disconnected()), this, SIGNAL(disconnected()));
@@ -18,11 +39,6 @@ BluetoothDevice::BluetoothDevice(const QBluetoothDeviceInfo& device, QObject *pa
     connect(&m_socket, SIGNAL(aboutToClose()), this, SIGNAL(aboutToClose()));
     connect(&m_socket, SIGNAL(error(QBluetoothSocket::SocketError)), this, SLOT(onError(QBluetoothSocket::SocketError)));
     connect(&m_socket, SIGNAL(stateChanged(QBluetoothSocket::SocketState)), this, SLOT(onStateChanged(QBluetoothSocket::SocketState)));
-}
-
-BluetoothDevice::~BluetoothDevice()
-{
-
 }
 
 QString BluetoothDevice::getBluetoothAddress() const
@@ -33,6 +49,11 @@ QString BluetoothDevice::getBluetoothAddress() const
 QString BluetoothDevice::getDeviceName() const
 {
     return this->m_device.name();
+}
+
+quint32 BluetoothDevice::getDeviceType() const
+{
+    return this->m_device.majorDeviceClass();
 }
 
 void BluetoothDevice::abortConnection(){

--- a/BBPebbleLib/Bluetooth/BluetoothDevice.h
+++ b/BBPebbleLib/Bluetooth/BluetoothDevice.h
@@ -32,10 +32,13 @@ class BluetoothDevice: public QObject
     Q_OBJECT
 public:
     BluetoothDevice(const QBluetoothDeviceInfo& device, QObject *parent = 0);
+    //! wrapper ctor to construct a BluetoothDevice from MAC and name
+    BluetoothDevice(const QString& mac, const QString& name, quint32 deviceClass, QObject *parent = 0);
     virtual ~BluetoothDevice();
 
     QString getBluetoothAddress() const;
     QString getDeviceName() const;
+    quint32 getDeviceType() const;
 
     void abortConnection();
     void connectToDevice();
@@ -58,6 +61,9 @@ private slots:
     void readyRead();
     void onError(QBluetoothSocket::SocketError error);
     void onStateChanged(QBluetoothSocket::SocketState state);
+
+    // connect signals and setup classes
+    void init();
 
 private:
     QBluetoothDeviceInfo m_device;


### PR DESCRIPTION
add ctor for constructing device with mac, name and device type.

this allows to create a device with saved values instead of having to start a discovery run.

discovery runs are very power intensive (see this [apple recommendation](https://developer.apple.com/library/content/documentation/NetworkingInternetWeb/Conceptual/CoreBluetooth_concepts/BestPracticesForInteractingWithARemotePeripheralDevice/BestPracticesForInteractingWithARemotePeripheralDevice.html)) so the new ctor allows to create and connect to a device, previously discovered.

thanks for the lib!