### PR TITLE
Workaround for multiple finished signals

### DIFF
--- a/BBPebbleLib/Bluetooth/Bluetooth.h
+++ b/BBPebbleLib/Bluetooth/Bluetooth.h
@@ -49,9 +49,12 @@ public slots:
 private slots:
     void onDiscovered(const QBluetoothDeviceInfo& info);
     void onError();
+    void discoveryFinished();
+    void discoveryCanceled();
 
 private:
     QBluetoothDeviceDiscoveryAgent* m_agent;
+    volatile bool m_discoveryRunning;
 };
 
 #endif /* BLUETOOTH_H_ */

--- a/BBPebbleLib/Bluetooth/BluetoothDevice.cpp
+++ b/BBPebbleLib/Bluetooth/BluetoothDevice.cpp
@@ -5,12 +5,33 @@
  *      Author: James
  */
 
+#include <QtConnectivity/QBluetoothAddress>
+
 #include "BluetoothDevice.h"
 
-BluetoothDevice::BluetoothDevice(const QBluetoothDeviceInfo& device, QObject *parent) : QObject(parent)
-{
-    this->m_device = device;
 
+BluetoothDevice::BluetoothDevice(const QBluetoothDeviceInfo& device, QObject *parent)
+    : QObject(parent)
+    , m_device(device)
+{
+    init();
+}
+
+BluetoothDevice::BluetoothDevice(const QString& mac, const QString& name, quint32 deviceClass, QObject *parent)
+    :QObject(parent)
+{
+    m_device = QBluetoothDeviceInfo(QtMobility::QBluetoothAddress(mac), name, deviceClass);
+
+    init();
+}
+
+BluetoothDevice::~BluetoothDevice()
+{
+
+}
+
+void BluetoothDevice::init()
+{
     connect(&m_socket, SIGNAL(readyRead()), this, SLOT(readyRead()));
     connect(&m_socket, SIGNAL(connected()), this, SIGNAL(connected()));
     connect(&m_socket, SIGNAL(disconnected()), this, SIGNAL(disconnected()));
@@ -18,11 +39,6 @@ BluetoothDevice::BluetoothDevice(const QBluetoothDeviceInfo& device, QObject *pa
     connect(&m_socket, SIGNAL(aboutToClose()), this, SIGNAL(aboutToClose()));
     connect(&m_socket, SIGNAL(error(QBluetoothSocket::SocketError)), this, SLOT(onError(QBluetoothSocket::SocketError)));
     connect(&m_socket, SIGNAL(stateChanged(QBluetoothSocket::SocketState)), this, SLOT(onStateChanged(QBluetoothSocket::SocketState)));
-}
-
-BluetoothDevice::~BluetoothDevice()
-{
-
 }
 
 QString BluetoothDevice::getBluetoothAddress() const
@@ -33,6 +49,11 @@ QString BluetoothDevice::getBluetoothAddress() const
 QString BluetoothDevice::getDeviceName() const
 {
     return this->m_device.name();
+}
+
+quint32 BluetoothDevice::getDeviceType() const
+{
+    return this->m_device.majorDeviceClass();
 }
 
 void BluetoothDevice::abortConnection(){

--- a/BBPebbleLib/Bluetooth/BluetoothDevice.cpp
+++ b/BBPebbleLib/Bluetooth/BluetoothDevice.cpp
@@ -32,6 +32,7 @@ BluetoothDevice::~BluetoothDevice()
 
 void BluetoothDevice::init()
 {
+    disconnect(&m_socket);
     connect(&m_socket, SIGNAL(readyRead()), this, SLOT(readyRead()));
     connect(&m_socket, SIGNAL(connected()), this, SIGNAL(connected()));
     connect(&m_socket, SIGNAL(disconnected()), this, SIGNAL(disconnected()));

--- a/BBPebbleLib/Bluetooth/BluetoothDevice.h
+++ b/BBPebbleLib/Bluetooth/BluetoothDevice.h
@@ -32,10 +32,13 @@ class BluetoothDevice: public QObject
     Q_OBJECT
 public:
     BluetoothDevice(const QBluetoothDeviceInfo& device, QObject *parent = 0);
+    //! wrapper ctor to construct a BluetoothDevice from MAC and name
+    BluetoothDevice(const QString& mac, const QString& name, quint32 deviceClass, QObject *parent = 0);
     virtual ~BluetoothDevice();
 
     QString getBluetoothAddress() const;
     QString getDeviceName() const;
+    quint32 getDeviceType() const;
 
     void abortConnection();
     void connectToDevice();
@@ -58,6 +61,9 @@ private slots:
     void readyRead();
     void onError(QBluetoothSocket::SocketError error);
     void onStateChanged(QBluetoothSocket::SocketState state);
+
+    // connect signals and setup classes
+    void init();
 
 private:
     QBluetoothDeviceInfo m_device;

--- a/BBPebbleLib/Enums.h
+++ b/BBPebbleLib/Enums.h
@@ -76,6 +76,7 @@ namespace Enums
         static const quint16 DataLog = 6778;
         static const quint16 SCREENSHOT = 8000;
         static const quint16 CoreDump = 9000;
+        static const quint16 BlobDB = 45531;
         static const quint16 PutBytes = 48879;
         static const quint16 MaxEndpoint = 65535; //quint16 max value
     }

--- a/BBPebbleLib/Pebble.cpp
+++ b/BBPebbleLib/Pebble.cpp
@@ -190,7 +190,7 @@ void Pebble::notifyTwitter(const QString &sender, const QString &body) const {
     sendNotification(Enums::Notifications::Twitter, strings);
 }
 
-void Pebble::sendNewNotification(const QString& sender, const QString& subject, const QString& data) const
+QByteArray Pebble::sendNewNotification(const QString& sender, const QString& subject, const QString& data) const
 {
     // default source
     int source = 1;
@@ -262,6 +262,22 @@ void Pebble::sendNewNotification(const QString& sender, const QString& subject, 
     blob.append(itemId); // key
     blob.append(item.length() & 0xFF); blob.append((item.length() >> 8) & 0xFF); // value length
     blob.append(item);
+
+    sendDataToPebble(Enums::Endpoint::BlobDB, blob);
+
+    return itemId;
+}
+
+void Pebble::deleteNewNotification(QByteArray itemId) const
+{
+    const int token = (qrand() % ((int)pow(2, 16) - 2)) + 1;
+
+    QByteArray blob;
+    blob.append(0x04); // command = delete
+    blob.append(token & 0xFF); blob.append((token >> 8) & 0xFF); // token
+    blob.append(0x04); //database id = notification
+    blob.append(itemId.length() & 0xFF); // key length
+    blob.append(itemId); // key
 
     sendDataToPebble(Enums::Endpoint::BlobDB, blob);
 }

--- a/BBPebbleLib/Pebble.cpp
+++ b/BBPebbleLib/Pebble.cpp
@@ -168,6 +168,14 @@ void Pebble::notifyTwitter(const QString &sender, const QString &body) const {
     sendNotification(Enums::Notifications::Twitter, strings);
 }
 
+void Pebble::sendNewNotification() const
+{
+    QByteArray notificationArray;
+    QDataStream in(&notificationArray, QIODevice::WriteOnly);
+
+    sendDataToPebble(Enums::Endpoint::Notification, notificationArray);
+}
+
 void Pebble::sendNotification(quint8 type, const QStringList &strings) const {
     QByteArray notificationArray;
     QDataStream in(&notificationArray, QIODevice::WriteOnly);

--- a/BBPebbleLib/Pebble.cpp
+++ b/BBPebbleLib/Pebble.cpp
@@ -91,6 +91,23 @@ void Pebble::sendDataToPebble(quint16 endPoint, const QByteArray &payload) const
     this->bt_device->sendData(finalData);
 }
 
+void Pebble::setTime() const
+{
+    QByteArray res;
+    QDateTime UTC(QDateTime::currentDateTimeUtc());
+    QDateTime local(UTC.toLocalTime());
+    local.setTimeSpec(Qt::UTC);
+    int offset = UTC.secsTo(local);
+    uint val = (local.toMSecsSinceEpoch() + offset) / 1000;
+
+    res.append(0x02); //SET_TIME_REQ
+    res.append((char)((val >> 24) & 0xff));
+    res.append((char)((val >> 16) & 0xff));
+    res.append((char)((val >> 8) & 0xff));
+    res.append((char)(val & 0xff));
+    sendDataToPebble(Enums::Endpoint::Time, res);
+}
+
 void Pebble::pingPebble(quint32 pingData) const {
     QByteArray bytes;
     QDataStream in(&bytes, QIODevice::WriteOnly);

--- a/BBPebbleLib/Pebble.cpp
+++ b/BBPebbleLib/Pebble.cpp
@@ -87,7 +87,9 @@ void Pebble::onDataReceived(QBluetoothSocket &bt_socket)
     }
 }
 
-void Pebble::onDataReadFinished(quint16 endPoint, const QByteArray &payload){
+void Pebble::onDataReadFinished(quint16 endPoint, const QByteArray &payload) {
+    Q_UNUSED(payload);
+
     //PhoneVersion is received immediatly after connecting to Pebble. We must respond to it first.
     if(!pebbleReady && endPoint == Enums::Endpoint::PhoneVersion) {
         unsigned int sessionCap = Enums::Session::GAMMA_RAY;

--- a/BBPebbleLib/Pebble.cpp
+++ b/BBPebbleLib/Pebble.cpp
@@ -107,6 +107,9 @@ void Pebble::sendDataToPebble(quint16 endPoint, const QByteArray &payload) const
     in << (quint16)endPoint;
     finalData.append(payload);
     in.setByteOrder(QDataStream::BigEndian);
+
+    qDebug() << ">>>> sent data. Endpoint : " << endPoint << " Payload Size : " << payload.size() << " HEX : " << payload.toHex() << "STR : " << QString(payload);
+
     this->bt_device->sendData(finalData);
 }
 

--- a/BBPebbleLib/Pebble.cpp
+++ b/BBPebbleLib/Pebble.cpp
@@ -6,6 +6,9 @@
  */
 
 #include <QtEndian>
+#include <QDateTime>
+
+#include "math.h"
 
 #include "Pebble.h"
 
@@ -168,12 +171,78 @@ void Pebble::notifyTwitter(const QString &sender, const QString &body) const {
     sendNotification(Enums::Notifications::Twitter, strings);
 }
 
-void Pebble::sendNewNotification() const
+void Pebble::sendNewNotification(const QString& sender, const QString& subject, const QString& data) const
 {
-    QByteArray notificationArray;
-    QDataStream in(&notificationArray, QIODevice::WriteOnly);
+    // default source
+    int source = 1;
 
-    sendDataToPebble(Enums::Endpoint::Notification, notificationArray);
+    int attributesCount = 0;
+    QByteArray attributes;
+
+    attributesCount++;
+    QByteArray senderBytes = sender.left(64).toUtf8();
+    attributes.append(0x01); // id = title
+    attributes.append(senderBytes.length() & 0xFF); attributes.append(((senderBytes.length() >> 8) & 0xFF)); // length
+    attributes.append(senderBytes); // content
+
+    attributesCount++;
+    QByteArray subjectBytes = (subject.isEmpty() ? data : subject).left(64).toUtf8();
+    attributes.append(0x02); // id = subtitle
+    attributes.append(subjectBytes.length() & 0xFF); attributes.append((subjectBytes.length() >> 8) & 0xFF); // length
+    attributes.append(subjectBytes); //content
+
+    if (!data.isEmpty()) {
+        attributesCount++;
+        QByteArray dataBytes = data.left(512).toUtf8();
+        attributes.append(0x03); // id = body
+        attributes.append(dataBytes.length() & 0xFF); attributes.append((dataBytes.length() >> 8) & 0xFF); // length
+        attributes.append(dataBytes); // content
+    }
+
+    attributesCount++;
+    attributes.append(0x04); // id = tinyicon
+    attributes.append(0x04); attributes.append('\0'); // length
+    attributes.append(source); attributes.append('\0'); attributes.append('\0'); attributes.append('\0'); // content
+
+
+    QByteArray actions;
+    actions.append('\0'); // action id
+    actions.append(0x04); // type = dismiss
+    actions.append(0x01); // attributes length = 1
+    actions.append(0x01); // attribute id = title
+    actions.append(0x07); actions.append('\0'); // attribute length
+    actions.append("Dismiss"); // attribute content
+
+
+    QByteArray itemId = QUuid::createUuid().toRfc4122();
+    int time = QDateTime::currentMSecsSinceEpoch() / 1000;
+    QByteArray item;
+    item.append(itemId); // item id
+    item.append(QUuid().toRfc4122()); // parent id
+    item.append(time & 0xFF); item.append((time >> 8) & 0xFF); item.append((time >> 16) & 0xFF); item.append((time >> 24) & 0xFF); // timestamp
+    item.append('\0'); item.append('\0'); // duration
+    item.append(0x01); // type: notification
+    item.append('\0'); item.append('\0'); // flags
+    item.append(0x01); // layout
+
+    int length = attributes.length() + actions.length();
+    item.append(length & 0xFF); item.append((length >> 8) & 0xFF); // data length
+    item.append(attributesCount); // attributes count
+    item.append(0x01); // actions count
+    item.append(attributes);
+    item.append(actions);
+
+    int token = (qrand() % ((int)pow(2, 16) - 2)) + 1;
+    QByteArray blob;
+    blob.append(0x01); // command = insert
+    blob.append(token & 0xFF); blob.append((token >> 8) & 0xFF); // token
+    blob.append(0x04); //database id = notification
+    blob.append(itemId.length() & 0xFF); // key length
+    blob.append(itemId); // key
+    blob.append(item.length() & 0xFF); blob.append((item.length() >> 8) & 0xFF); // value length
+    blob.append(item);
+
+    sendDataToPebble(Enums::Endpoint::BlobDB, blob);
 }
 
 void Pebble::sendNotification(quint8 type, const QStringList &strings) const {

--- a/BBPebbleLib/Pebble.cpp
+++ b/BBPebbleLib/Pebble.cpp
@@ -204,11 +204,13 @@ void Pebble::sendNewNotification(const QString& sender, const QString& subject, 
     attributes.append(senderBytes.length() & 0xFF); attributes.append(((senderBytes.length() >> 8) & 0xFF)); // length
     attributes.append(senderBytes); // content
 
-    attributesCount++;
-    QByteArray subjectBytes = (subject.isEmpty() ? data : subject).left(64).toUtf8();
-    attributes.append(0x02); // id = subtitle
-    attributes.append(subjectBytes.length() & 0xFF); attributes.append((subjectBytes.length() >> 8) & 0xFF); // length
-    attributes.append(subjectBytes); //content
+    if (!subject.isEmpty()) {
+        attributesCount++;
+        QByteArray subjectBytes = subject.left(64).toUtf8();
+        attributes.append(0x02); // id = subtitle
+        attributes.append(subjectBytes.length() & 0xFF); attributes.append((subjectBytes.length() >> 8) & 0xFF); // length
+        attributes.append(subjectBytes); //content
+    }
 
     if (!data.isEmpty()) {
         attributesCount++;

--- a/BBPebbleLib/Pebble.cpp
+++ b/BBPebbleLib/Pebble.cpp
@@ -5,6 +5,8 @@
  *      Author: James
  */
 
+#include <QtEndian>
+
 #include "Pebble.h"
 
 const quint8 Pebble::PEBBLE_CLIENT_VERSION = 2;
@@ -38,31 +40,48 @@ void Pebble::onDisconnect()
 
 void Pebble::onDataReceived(QBluetoothSocket &bt_socket)
 {
-    QDataStream in(&bt_socket);
+    static const int header_length = (int)2*sizeof(quint16);
 
-    if (this->payloadSize == 0) {
-        if (bt_socket.bytesAvailable() < (int)2*sizeof(quint16)) {
+    while (bt_socket.bytesAvailable() >= header_length) {
+        // Take a look at the header, but do not remove it from the socket input buffer.
+        // We will only remove it once we're sure the entire packet is in the buffer.
+        uchar header[header_length];
+        bt_socket.peek(reinterpret_cast<char*>(header), header_length);
+
+        quint16 message_length = qFromBigEndian<quint16>(&header[0]);
+        quint16 endpoint = qFromBigEndian<quint16>(&header[2]);
+
+        // Sanity checks on the message_length
+        if (message_length == 0) {
+            qDebug() << "received empty message";
+            bt_socket.read(header_length); // skip this header
+            continue; // check if there are additional headers.
+        } else if (message_length > 8 * 1024) {
+            // Protocol does not allow messages more than 8K long, seemingly.
+            qDebug() << "received message size too long: " << message_length;
+            bt_socket.readAll(); // drop entire input buffer
             return;
         }
-        in >> this->payloadSize;
-        in >> this->endPoint;
+
+        // Now wait for the entire message
+        if (bt_socket.bytesAvailable() < header_length + message_length) {
+            qDebug() << "incomplete msg body in read buffer";
+            return; // try again once more data comes in
+        }
+
+        // We can now safely remove the header from the input buffer,
+        // as we know the entire message is in the input buffer.
+        bt_socket.read(header_length);
+
+        // Now read the rest of the message
+        QByteArray data = bt_socket.read(message_length);
+
+        qDebug() << "<<<< received data. Endpoint : " << endpoint << " Payload Size : " << data.size() << " HEX : " << data.toHex() << "STR : " << QString(data);
+
+        emit onDataReadFinished(endpoint, data);
+
+        onDataReceived(bt_socket);
     }
-
-    if(bt_socket.bytesAvailable() < this->payloadSize){
-        return;
-    }
-    char buffer[this->payloadSize];
-    in.readRawData(buffer, this->payloadSize);
-    QByteArray payload(buffer);
-
-    qDebug() << "Received data. Endpoint : " << endPoint << " Payload Size : " << payloadSize << " HEX : " << payload.toHex() << "STR : " << QString(payload);
-
-    emit onDataReadFinished(endPoint, payload);
-
-    this->payloadSize = 0;
-    this->endPoint = 0;
-
-    onDataReceived(bt_socket);
 }
 
 void Pebble::onDataReadFinished(quint16 endPoint, const QByteArray &payload){

--- a/BBPebbleLib/Pebble.cpp
+++ b/BBPebbleLib/Pebble.cpp
@@ -79,7 +79,7 @@ void Pebble::onDataReceived(QBluetoothSocket &bt_socket)
         // Now read the rest of the message
         QByteArray data = bt_socket.read(message_length);
 
-        qDebug() << "<<<< received data. Endpoint : " << endpoint << " Payload Size : " << data.size() << " HEX : " << data.toHex() << "STR : " << QString(data);
+        qDebug() << "<<<< recv data.\nEndpoint:" << endpoint << "\nPayload Size:" << data.size() << "\nHEX:" << data.toHex();
 
         emit onDataReadFinished(endpoint, data);
 
@@ -136,7 +136,7 @@ void Pebble::sendDataToPebble(quint16 endPoint, const QByteArray &payload) const
     finalData.append(payload);
     in.setByteOrder(QDataStream::BigEndian);
 
-    qDebug() << ">>>> sent data. Endpoint : " << endPoint << " Payload Size : " << payload.size() << " HEX : " << payload.toHex() << "STR : " << QString(payload);
+    qDebug() << ">>>> send data.\nEndpoint:" << endPoint << "\nPayload Size:" << payload.size() << "\nHEX:" << payload.toHex();
 
     this->bt_device->sendData(finalData);
 }

--- a/BBPebbleLib/Pebble.h
+++ b/BBPebbleLib/Pebble.h
@@ -27,6 +27,7 @@ public:
     void sendDataToPebble(quint16 endPoint, const QByteArray &payload) const;
 
     void pingPebble(quint32 pingData = 0) const;
+    void sendNewNotification() const;
     void notifyEmail(const QString &sender, const QString &subject, const QString &body) const;
     void notifySMS(const QString &sender, const QString &body) const;
     void notifyFacebook(const QString &sender, const QString &body) const;

--- a/BBPebbleLib/Pebble.h
+++ b/BBPebbleLib/Pebble.h
@@ -28,7 +28,9 @@ public:
 
     void setTime() const;
     void pingPebble(quint32 pingData = 0) const;
-    void sendNewNotification(const QString& sender, const QString& subject, const QString& data) const;
+    //! return item id for BlobDB
+    QByteArray sendNewNotification(const QString& sender, const QString& subject, const QString& data) const;
+    void deleteNewNotification(QByteArray itemId) const;
     void notifyEmail(const QString &sender, const QString &subject, const QString &body) const;
     void notifySMS(const QString &sender, const QString &body) const;
     void notifyFacebook(const QString &sender, const QString &body) const;

--- a/BBPebbleLib/Pebble.h
+++ b/BBPebbleLib/Pebble.h
@@ -26,6 +26,7 @@ public:
 
     void sendDataToPebble(quint16 endPoint, const QByteArray &payload) const;
 
+    void setTime() const;
     void pingPebble(quint32 pingData = 0) const;
     void notifyEmail(const QString &sender, const QString &subject, const QString &body) const;
     void notifySMS(const QString &sender, const QString &body) const;

--- a/BBPebbleLib/Pebble.h
+++ b/BBPebbleLib/Pebble.h
@@ -27,7 +27,7 @@ public:
     void sendDataToPebble(quint16 endPoint, const QByteArray &payload) const;
 
     void pingPebble(quint32 pingData = 0) const;
-    void sendNewNotification() const;
+    void sendNewNotification(const QString& sender, const QString& subject, const QString& data) const;
     void notifyEmail(const QString &sender, const QString &subject, const QString &body) const;
     void notifySMS(const QString &sender, const QString &body) const;
     void notifyFacebook(const QString &sender, const QString &body) const;

--- a/README.md
+++ b/README.md
@@ -15,3 +15,12 @@ I am expecting (hopefully) to not be the only one to contribute to this project 
 * Get information of an application
 * Displaying Weather on a watchface
 * Much much much more
+
+### Related Work
+Thanks to all the other projects which achieved communication with the Pebble watch and inspired/helped this project, namely:
+* https://github.com/smokku/pebble
+* https://github.com/Hexxeh/libpebble
+* https://github.com/pebble/libpebble2
+* https://github.com/Keboo/PebbleSharp
+* https://github.com/DouweM/pebblewatch
+* https://github.com/barometz/flint


### PR DESCRIPTION
for whatever reason, QBluetoothDeviceDiscoveryAgent seems to emit multiple finished() signals after discovery is finished. 

the workaround is to keep track if discovery was started and ignore the other occurances